### PR TITLE
Add temporary a environment variable when the plugin is doing a backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
-autoSaver
-===================
-The plugin allows saving project and layers in edit mode at user defined interval
+# autoSaver
+
+## Features
+
+The plugin allows the automatic saving of the project and layers in edit mode at a user-defined interval.
+
+## PyQGIS
+
+For PyQGIS plugin developers, the plugin will change the
+[QgsProject filename](https://api.qgis.org/api/classQgsProject.html#a49c729d8fac976c0a91df3573002bfa0) in the
+background **temporary**.
+So QGIS will trigger the signal `fileNameChanged`.
+
+If your plugin or script is listening to this signal, it's somehow a false positive because the user
+didn't change the filename on purpose and the plugin will set back the normal filename after the backup is made.
+
+For this reason, when the `fileNameChanged` is emitted, you can check if the environment variable
+`QGIS_PLUGIN_AUTO_SAVING` is present.
+If yes, it means it has been the plugin doing the backup file.

--- a/autosave.py
+++ b/autosave.py
@@ -390,11 +390,17 @@ class autoSaver:
             else:
                 bakFileName = origFileName
                 msg = "project autosaved"
+
+            # The environment QGIS_PLUGIN_AUTO_SAVING can be used to
+            os.environ['QGIS_PLUGIN_AUTO_SAVER'] = str(True)
             QgsProject.instance().setFileName(bakFileName)
             QgsProject.instance().write()
             QgsProject.instance().setFileName(origFileName)
             if self.dlg.enableAlternate.isChecked():
                 os.rename(bakFileName, targetBakFile)
+
+            del os.environ['QGIS_PLUGIN_AUTO_SAVING']
+
             self.iface.messageBar().pushSuccess("Autosaver", msg)
 
     def run(self):


### PR DESCRIPTION
To be used in a another plugin, because the user did not really change the filename

See the explication in the README.md file

CC @enricofer 