### PR TITLE
Check if the variable is still here before removing it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # autoSaver
 
+[![QGIS.org](https://img.shields.io/badge/QGIS.org-published-green)](https://plugins.qgis.org/plugins/autoSaver/)
+
 ## Features
 
 The plugin allows the automatic saving of the project and layers in edit mode at a user-defined interval.

--- a/autosave.py
+++ b/autosave.py
@@ -401,7 +401,9 @@ class autoSaver:
                 bakFileName = origFileName
                 msg = "project autosaved"
 
-            # The environment QGIS_PLUGIN_AUTO_SAVING can be used to
+            # The environment variable QGIS_PLUGIN_AUTO_SAVING can be used to notify other processes that the
+            # QgsProject.instance() object is going to be updated temporary.
+            # Indeed, other plugins can listen to the signal QgsProject::fileNameChanged()
             os.environ['QGIS_PLUGIN_AUTO_SAVER'] = str(True)
             QgsProject.instance().setFileName(bakFileName)
             QgsProject.instance().write()
@@ -409,7 +411,12 @@ class autoSaver:
             if self.dlg.enableAlternate.isChecked():
                 os.rename(bakFileName, targetBakFile)
 
-            del os.environ['QGIS_PLUGIN_AUTO_SAVING']
+            try:
+                # https://github.com/enricofer/autoSaver/issues/23
+                # Do not raise any error if the variable is already not here anymore
+                del os.environ['QGIS_PLUGIN_AUTO_SAVING']
+            except KeyError:
+                pass
 
             self.iface.messageBar().pushSuccess("Autosaver", msg)
 


### PR DESCRIPTION
I'm not sure why, but I still have the issue, but when I was trying it on Monday, it was fine.

I have temporary disabled the latest release on plugins.qgis.org, as the latest feature doesn't bring any new feature.

Fix #23

Follow up from https://github.com/enricofer/autoSaver/pull/19